### PR TITLE
chore: change backend server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,9 +29,9 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: process.env.NODE_ENV === "test" ? "http://localhost:8000" : "https://api.noj.tw",
+        target: process.env.NODE_ENV === "test" ? "http://localhost:8000" : "https://noj-preview1.little7.pp.ua",
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ""),
+        // rewrite: (path) => path.replace(/^\/api/, ""),
       },
     },
   },


### PR DESCRIPTION
This pull request updates the API proxy configuration in `vite.config.ts` to use a new preview server for non-test environments and comments out the proxy path rewrite.

* **API Proxy Configuration Update**:
  - Changed the proxy target for `/api` from `https://api.noj.tw` to `https://noj-preview1.little7.pp.ua` when not in test mode.
  - Commented out the path rewrite function for the API proxy, so the `/api` prefix is no longer removed from proxied requests.