### PR TITLE
fix: update token provider to use null for session initialization

### DIFF
--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -61,7 +61,5 @@ export const useSession = defineStore("session", {
 
 // To avoid circular dependency, export a function to set the token provider after store initialization.
 export function initSessionTokenProvider(sessionStore: ReturnType<typeof useSession>) {
-  setTokenProvider(() => {
-    return sessionStore.token || null;
-  });
+  setTokenProvider(() => null); // 用 Cookie，不加 Authorization header
 }


### PR DESCRIPTION
This pull request makes a targeted change to the session token provider initialization logic. The update ensures that the token provider always returns `null`, which means authentication will rely on cookies instead of sending an `Authorization` header.

* Changed the `initSessionTokenProvider` function in `src/stores/session.ts` to always set the token provider to return `null`, indicating that authentication should use cookies rather than an `Authorization` header.