### PR TITLE
fix: set store refresh token in local storage

### DIFF
--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -98,6 +98,7 @@ export function initSessionTokenProvider(sessionStore: ReturnType<typeof useSess
     try {
       const { access } = await api.Auth.refresh({ refresh: sessionStore.refreshtoken });
       sessionStore.token = access; // 更新新 access
+      localStorage.setItem(ACCESS_KEY, access);
       return access;
     } catch {
       sessionStore.logoutLocally();


### PR DESCRIPTION
This pull request makes a small update to the session token refresh logic. After obtaining a new access token, it is now also saved to `localStorage` to ensure the token persists across page reloads and browser sessions.