### PR TITLE
fix: rename identity to role in auth interface

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -6,7 +6,7 @@ export const Auth = {
     password: string;
     email: string;
     real_name: string;
-    identity: string;
+    role: string;
     student_id?: string;
     bio?: string;
   }) => fetcher.post<UserSignup>("/auth/signup/", body).then((r) => r.data ?? r),

--- a/src/types/auth.d.ts
+++ b/src/types/auth.d.ts
@@ -10,7 +10,7 @@ interface UserSignup {
   username: string;
   email: string;
   userid: string;
-  identity: string;
+  role: string;
   date_joined: string;
   last_login: string | null;
 }


### PR DESCRIPTION
This pull request makes a small change to the user signup API by replacing the `identity` field with a `role` field in the request body. This clarifies the expected data and likely improves consistency with backend requirements.