### PR TITLE
chore: update API server target URL in Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: process.env.NODE_ENV === "test" ? "http://localhost:8000" : "https://noj-preview1.little7.pp.ua",
+        target: process.env.NODE_ENV === "test" ? "http://localhost:8000" : "https://noj-backend-dev.little7.pp.ua",
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ""),
       },


### PR DESCRIPTION
This pull request makes a minor configuration update to the development server proxy target in `vite.config.ts`. The change updates the backend URL used for non-test environments.

* Updated the proxy target for `/api` requests to point to `https://noj-backend-dev.little7.pp.ua` instead of the previous preview URL in `vite.config.ts`.