### PR TITLE
refactor: simplify Course info retrieval and enhance type definitions

### DIFF
--- a/src/api/course.ts
+++ b/src/api/course.ts
@@ -3,28 +3,7 @@ import { fetcher } from "./fetcher";
 export const Course = {
   create: (body: CourseForm) => fetcher.post("/course/", body),
   list: () => fetcher.get<{ courses: CourseList }>("/course/"),
-  info: (courseId: string) =>
-    fetcher.get<Course>(`/course/${courseId}/`).then((res) => {
-      if (!res?.data) return res;
-      return {
-        ...res,
-        data: {
-          ...res.data,
-          teacher: {
-            ...res.data.teacher,
-            role: "teacher",
-          },
-          TAs: (res.data.TAs ?? []).map((ta) => ({
-            ...ta,
-            role: "ta",
-          })),
-          students: (res.data.students ?? []).map((student) => ({
-            ...student,
-            role: "student",
-          })),
-        },
-      };
-    }),
+  info: (courseId: string) => fetcher.get<Course>(`/course/${courseId}/`),
 };
 
 export const Announcement = {

--- a/src/types/course.d.ts
+++ b/src/types/course.d.ts
@@ -25,6 +25,9 @@ interface CourseInfo {
   isActive: boolean;
   createdAt: string;
   updatedAt: string;
+  teacher: Pick<User, "userid" | "username" | "real_name" | "role">;
+  TAs: Pick<User, "userid" | "username" | "real_name" | "role">[];
+  students: Pick<User, "userid" | "username" | "real_name" | "role">[];
 }
 
 interface CourseForm {


### PR DESCRIPTION
This pull request simplifies the `info` method in the `Course` API by removing logic that manually assigns roles to users in the course data. Now, the method simply fetches the course information without modifying the response.

- API simplification:
  * [`src/api/course.ts`]: The `Course.info` method no longer processes the fetched course data to assign `role` fields to teachers, TAs, and students; it now returns the API response as-is.