### PR TITLE
feat: Add 'Manage' link to course top bar navigation.

### DIFF
--- a/src/components/Course/CourseTopBar.vue
+++ b/src/components/Course/CourseTopBar.vue
@@ -14,6 +14,7 @@ const items: ComputedRef<{ [k: string | symbol]: { path: null | string; text: st
   const problemsPage = { path: `/courses/${route.params.courseId}/problems`, text: "Problems" };
   const submissionsPage = { path: `/courses/${route.params.courseId}/submissions`, text: "Submissions" };
   const membersPage = { path: `/courses/${route.params.courseId}/members`, text: "Members" };
+  const managePage = { path: `/courses/${route.params.courseId}/manage`, text: "Manage" };
 
   return {
     "courses-courseId-announcements": [{ path: null, text: "Announcements" }],


### PR DESCRIPTION
This pull request makes a minor update to the navigation items in the `CourseTopBar` component by adding a new "Manage" section to the course navigation.

- Added a "Manage" navigation item to the course top bar in `CourseTopBar.vue`