### PR TITLE
fix: ensure post-login redirect defaults to home if target is login page

### DIFF
--- a/src/components/Home/LoginSection.vue
+++ b/src/components/Home/LoginSection.vue
@@ -41,9 +41,22 @@ async function login() {
     console.log(tokens);
     await session.setTokens(tokens.access, tokens.refresh);
     let redirect = (route.query.redirect as string) ?? "/";
-    if (redirect.startsWith("/login")) {
+
+    // Prevent open redirect: must start with / and not //
+    if (!redirect.startsWith("/") || redirect.startsWith("//")) {
       redirect = "/";
     }
+
+    try {
+      const redirectUrl = new URL(redirect, window.location.origin);
+      const redirectPath = redirectUrl.pathname;
+      if (redirectPath === "/login" || redirectPath.startsWith("/login/")) {
+        redirect = "/";
+      }
+    } catch {
+      redirect = "/";
+    }
+
     router.replace(redirect);
   } catch (error: any) {
     if (axios.isAxiosError(error)) {


### PR DESCRIPTION
This pull request makes a small but important improvement to the login flow. After a successful login, users will no longer be redirected back to the login page, even if the `redirect` query parameter is set to a login route.

* Prevents redirecting users to `/login` after successful authentication by checking if the `redirect` path starts with `/login` and defaulting to `/` instead.