### PR TITLE
feat: add router link to user page in ranking table

### DIFF
--- a/src/pages/ranking/index.vue
+++ b/src/pages/ranking/index.vue
@@ -103,7 +103,7 @@ onMounted(async () => {
                 :aria-label="`View profile of ${item.user.username}`"
                 :title="`View profile of ${item.user.username}`"
               >
-                {{ item.user?.real_name || "-" }}
+                {{ item.user.real_name || "-" }}
               </router-link>
               <span v-else>{{ item.user?.real_name || "-" }}</span>
             </td>


### PR DESCRIPTION
This pull request improves the user experience on the ranking page by making usernames, real names, and avatars clickable links to user profiles when available. It also updates the table headers for clarity.

**User profile linking enhancements:**

* User avatars, usernames, and real names are now clickable links to the user's profile page if a username exists. If not, they remain non-clickable elements.

**UI and localization improvements:**

* Table headers have been updated to use more consistent and clear localization keys (`profile.username` and `profile.realName` instead of `ranking.table.userId` and `ranking.table.displayName`).