### PR TITLE
feat: assign TA in course manage page

### DIFF
--- a/src/api/course.ts
+++ b/src/api/course.ts
@@ -28,6 +28,8 @@ export const Course = {
   getSummary: () => fetcher.get<CourseSummary>("/course/summary/"),
   getScoreBoard: (courseId: string | number, params: { pids: string; start?: number; end?: number }) =>
     fetcher.get<ScoreBoardResponse>(`/course/${courseId}/scoreboard/`, { params }),
+  assignTA: (courseId: string | number, body: { username: string }) =>
+    fetcher.post<{ message: string; status_code: number }>(`/course/${courseId}/assign-ta/`, body),
 };
 
 export const Announcement = {


### PR DESCRIPTION
This pull request introduces a new feature for managing Teacher Assistants (TAs) in the course management page. It adds the ability to view the current list of TAs and assign new TAs to a course through the UI, along with backend API integration and improved state handling.

**TA Management Enhancements:**

* Added a new API method `assignTA` in `src/api/course.ts` to assign a TA to a course by username.
* Refactored the course management page (`src/pages/courses/[courseId]/manage.vue`) to display the current list of TAs, and provide a form to assign a new TA by username.
* Updated the course info fetching logic to store and display the list of current TAs as an array instead of a comma-separated string.
* Implemented error handling and UI feedback for TA assignment actions, including success and error messages. 
* Added local state variables and a new `assignTA` function to handle the TA assignment process in the frontend. 