### PR TITLE
fix: reset form fields after importing members via CSV

### DIFF
--- a/src/auto/components.d.ts
+++ b/src/auto/components.d.ts
@@ -24,6 +24,7 @@ declare module '@vue/runtime-core' {
     IUilAngleDown: typeof import('~icons/uil/angle-down')['default']
     IUilBan: typeof import('~icons/uil/ban')['default']
     IUilBolt: typeof import('~icons/uil/bolt')['default']
+    IUilBookOpen: typeof import('~icons/uil/book-open')['default']
     IUilChartLine: typeof import('~icons/uil/chart-line')['default']
     IUilCheck: typeof import('~icons/uil/check')['default']
     IUilCheckCircle: typeof import('~icons/uil/check-circle')['default']

--- a/src/pages/courses/[courseId]/members.vue
+++ b/src/pages/courses/[courseId]/members.vue
@@ -96,6 +96,12 @@ async function submit() {
     if (!newMembers.value) return;
     await api.Course.importCSV(route.params.courseId as string, newMembers.value, forceUpdate.value);
     await loadMembers();
+    isOpen.value = false;
+    newMembers.value = null;
+    newMembersCSVString.value = "";
+    previewCSV.value = {};
+    forceUpdate.value = false;
+    errorMsg.value = "";
   } catch (error) {
     if (axios.isAxiosError(error) && error.response?.data?.message) {
       errorMsg.value = error.response.data.message;


### PR DESCRIPTION
This pull request makes a small update to the member import workflow. After successfully importing members via CSV, it now resets the relevant form and state variables to their default values, ensuring the import dialog is cleared and ready for future use.