### PR TITLE
feat: add ranking display avatar

### DIFF
--- a/src/pages/ranking/index.vue
+++ b/src/pages/ranking/index.vue
@@ -12,23 +12,13 @@ const error = ref<Error | null>(null);
 const getProfileLink = (username: string) => `/profile/${username}`;
 const fallbackAvatar = "https://i.pravatar.cc/100";
 
+const normalizePath = (path: string) => {
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  return normalized.startsWith("/avatars/") ? `/media${normalized}` : normalized;
+};
+
 const normalizeAvatar = (avatar?: string | null) => {
   if (!avatar) return fallbackAvatar;
-
-  const normalizePath = (path: string) => {
-    const normalized = path.startsWith("/") ? path : `/${path}`;
-    return normalized.startsWith("/avatars/") ? `/media${normalized}` : normalized;
-  };
-
-  if (avatar.startsWith("http://") || avatar.startsWith("https://")) {
-    try {
-      const parsed = new URL(avatar);
-      parsed.pathname = normalizePath(parsed.pathname);
-      return parsed.toString();
-    } catch {
-      return avatar;
-    }
-  }
 
   const mediaBase = import.meta.env.VITE_APP_MEDIA_BASE_URL || import.meta.env.VITE_APP_API_BASE_URL;
   let origin = window.location.origin;
@@ -37,6 +27,18 @@ const normalizeAvatar = (avatar?: string | null) => {
       origin = new URL(mediaBase, window.location.origin).origin;
     } catch {
       origin = window.location.origin;
+    }
+  }
+
+  if (avatar.startsWith("http://") || avatar.startsWith("https://")) {
+    try {
+      const parsed = new URL(avatar);
+      if (parsed.origin === origin) {
+        parsed.pathname = normalizePath(parsed.pathname);
+      }
+      return parsed.toString();
+    } catch {
+      return avatar;
     }
   }
 


### PR DESCRIPTION
This pull request improves the user ranking page by enhancing how user avatars are resolved and displayed, and by ensuring the ranking table is always sorted by the number of accepted problems. The changes increase robustness in avatar URL handling and make the leaderboard more reliable.

**Avatar handling improvements:**

* Added a `resolveAvatarUrl` function to consistently handle user avatar URLs, supporting both relative and absolute paths, defaulting to a fallback avatar if none is provided, and ensuring correct media base URL usage.
* Updated avatar image rendering to use the new `resolveAvatarUrl` function, replacing direct usage of the avatar URL or fallback. 

**Ranking table improvements:**

* Changed the ranking table to always sort users by the number of accepted problems (`ACProblem`), ensuring the leaderboard is correctly ordered regardless of input data order. 