### PR TITLE
fix: login section description

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -412,11 +412,11 @@
     "loginSection": {
       "welcome": "Welcome back, {user}",
       "signin": "Sign in",
-      "loginFailed": "Login Failed: Your username/email or password is incorrect",
-      "username": "Username / Email",
+      "loginFailed": "Login Failed: Your username or password is incorrect",
+      "username": "Username",
       "pw": "Password",
       "placeholder": {
-        "username": "username or email",
+        "username": "username",
         "pw": "password"
       },
       "forgot": "Forgot password?",

--- a/src/i18n/zh-tw.json
+++ b/src/i18n/zh-tw.json
@@ -410,11 +410,11 @@
     "loginSection": {
       "welcome": "歡迎回來，{user}",
       "signin": "登入",
-      "loginFailed": "登入失敗：帳號 / 電子郵件地址或是密碼輸入錯誤",
-      "username": "帳號 / 電子郵件地址",
+      "loginFailed": "登入失敗：帳號或是密碼輸入錯誤",
+      "username": "帳號",
       "pw": "密碼",
       "placeholder": {
-        "username": "帳號 / 電子郵件地址",
+        "username": "帳號",
         "pw": "密碼"
       },
       "forgot": "忘記密碼?",


### PR DESCRIPTION
This pull request updates the login section wording in both English and Traditional Chinese to clarify that only "username" (not email) is accepted for login. It also updates the related error messages and placeholders for consistency.

Localization and UI text updates:

* Updated `loginFailed`, `username`, and `placeholder.username` strings in `src/i18n/en.json` to remove references to "email" and clarify that only "username" is accepted.
* Updated `loginFailed`, `username`, and `placeholder.username` strings in `src/i18n/zh-tw.json` to remove references to "電子郵件地址" (email address) and clarify that only "帳號" (username) is accepted.