### PR TITLE
fix: improve sign-up form UX with loading state and form submission h…

### DIFF
--- a/src/auto/components.d.ts
+++ b/src/auto/components.d.ts
@@ -33,6 +33,7 @@ declare module 'vue' {
     IUilChartLine: typeof import('~icons/uil/chart-line')['default']
     IUilCheck: typeof import('~icons/uil/check')['default']
     IUilCheckCircle: typeof import('~icons/uil/check-circle')['default']
+    IUilCopy: typeof import('~icons/uil/copy')['default']
     IUilEdit: typeof import('~icons/uil/edit')['default']
     IUilExclamationCircle: typeof import('~icons/uil/exclamation-circle')['default']
     IUilExclamationTriangle: typeof import('~icons/uil/exclamation-triangle')['default']

--- a/src/components/Home/SignupSection.vue
+++ b/src/components/Home/SignupSection.vue
@@ -36,6 +36,7 @@ const rules = {
 
 const v$ = useVuelidate(rules, signupForm);
 async function signup() {
+  if (isLoading.value) return;
   const isFormCorrect = await v$.value.$validate();
   if (!isFormCorrect) return;
   isLoading.value = true;
@@ -91,7 +92,7 @@ async function signup() {
   <div class="card-container">
     <LoginSection v-if="session.isLogin" />
     <div v-else class="card min-w-full">
-      <div class="card-body space-y-3 pt-0">
+      <form class="card-body space-y-3 pt-0" @submit.prevent="signup">
         <div class="card-title mb-2">Sign up</div>
         <div class="alert alert-error shadow-lg" v-if="signupForm.errorMsg">
           <div>
@@ -189,9 +190,16 @@ async function signup() {
         </div>
 
         <div class="form-control mt-4">
-          <button class="btn btn-primary w-full" @click="signup">SIGN UP</button>
+          <button
+            class="btn btn-primary w-full"
+            :class="isLoading && 'loading'"
+            type="submit"
+            :disabled="isLoading"
+          >
+            SIGN UP
+          </button>
         </div>
-      </div>
+      </form>
     </div>
   </div>
 </template>


### PR DESCRIPTION
This pull request improves the user experience and reliability of the signup form in the `SignupSection.vue` component by preventing duplicate submissions and properly handling form submission events. The main changes are grouped below:

**Form Submission Handling:**

* Changed the signup form to use a `<form>` element with a `@submit.prevent="signup"` handler, ensuring that pressing Enter or clicking the button both trigger the signup logic in a standard way.

**Duplicate Submission Prevention & Button State:**

* Added a check in the `signup` function to immediately return if a signup is already in progress (`isLoading.value`), preventing duplicate requests.
* Updated the signup button to use `type="submit"` and bind its disabled and loading states to `isLoading`, providing visual feedback and preventing multiple submissions while a request is in progress.