### PR TITLE
fix: add warning messages for fields that cannot be changed after con…

### DIFF
--- a/src/components/Home/SignupSection.vue
+++ b/src/components/Home/SignupSection.vue
@@ -106,13 +106,10 @@ async function signup() {
           <input
             v-model="v$.username.$model"
             type="text"
-            placeholder="username"
+            placeholder="username (cannot be changed after confirmation)"
             class="input input-bordered"
             :class="v$.username.$error && 'input-error'"
           />
-          <label class="label">
-            <span class="label-text-alt opacity-70">This field cannot be changed after confirmation.</span>
-          </label>
           <label class="label" v-if="v$.username.$error">
             <span class="label-text-alt text-error">Required</span>
           </label>
@@ -124,15 +121,10 @@ async function signup() {
           <input
             v-model="v$.email.$model"
             type="email"
-            placeholder="email"
+            placeholder="email (must be valid and receivable)"
             class="input input-bordered"
             :class="v$.email.$error && 'input-error'"
           />
-          <label class="label">
-            <span class="label-text-alt opacity-70"
-              >Please enter a valid email address that can receive emails.</span
-            >
-          </label>
           <label class="label" v-if="v$.email.$error">
             <span class="label-text-alt text-error">
               {{ v$.email.required.$invalid ? "Required" : v$.email.email.$invalid ? "Invalid email" : "" }}
@@ -146,13 +138,10 @@ async function signup() {
           <input
             v-model="v$.realname.$model"
             type="text"
-            placeholder="your full name"
+            placeholder="your full name (cannot be changed after confirmation)"
             class="input input-bordered"
             :class="v$.realname.$error && 'input-error'"
           />
-          <label class="label">
-            <span class="label-text-alt opacity-70">This field cannot be changed after confirmation.</span>
-          </label>
           <label class="label" v-if="v$.realname.$error">
             <span class="label-text-alt text-error">Required</span>
           </label>
@@ -164,13 +153,10 @@ async function signup() {
           <input
             v-model="v$.studentID.$model"
             type="text"
-            placeholder="student ID"
+            placeholder="student ID (cannot be changed after confirmation)"
             class="input input-bordered"
             :class="v$.studentID.$error && 'input-error'"
           />
-          <label class="label">
-            <span class="label-text-alt opacity-70">This field cannot be changed after confirmation.</span>
-          </label>
         </div>
 
         <!-- Password -->


### PR DESCRIPTION
This pull request enhances the user experience in the signup form by adding helpful instructional labels to clarify the permanence of certain fields and the requirements for the email address. These changes aim to reduce user errors and set clear expectations during the signup process.

**User guidance improvements in the signup form:**

* Added a label below the `username`, `realname`, and `studentID` input fields to inform users that these fields cannot be changed after confirmation. 
* Added a label below the `email` input field to instruct users to enter a valid, accessible email address.