### PR TITLE
fix: update memory limit labels from KB to MB in ProblemCard and Prob…

### DIFF
--- a/src/components/Problem/ProblemCard.vue
+++ b/src/components/Problem/ProblemCard.vue
@@ -317,7 +317,7 @@ onMounted(() => {
               >
                 <td>{{ subtask_no }}</td>
                 <td>{{ time_limit_ms }} ms</td>
-                <td>{{ memory_limit_mb }} KB</td>
+                <td>{{ memory_limit_mb }} MB</td>
                 <td>{{ weight }}</td>
               </tr>
             </tbody>

--- a/src/components/Problem/ProblemForm.vue
+++ b/src/components/Problem/ProblemForm.vue
@@ -511,7 +511,7 @@ const removeDomain = (d: string) => {
                   </div>
 
                   <div class="form-control w-full">
-                    <label class="label"><span class="label-text">Memory Limit (KB)</span></label>
+                    <label class="label"><span class="label-text">Memory Limit (MB)</span></label>
                     <input class="input input-bordered w-full" :value="task.memoryLimit" readonly />
                   </div>
 


### PR DESCRIPTION
This pull request updates the display of memory limits in the problem-related components to use megabytes (MB) instead of kilobytes (KB). The change ensures consistency in both the label and the value shown to users.

Display updates for memory limit units:

* Changed the table display in `ProblemCard.vue` to show memory limits in MB instead of KB.
* Updated the form label in `ProblemForm.vue` to indicate memory limits are in MB, matching the displayed value.